### PR TITLE
Add auto-derived traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["data-structures"]
 
 [dependencies]
 fid = "0.1.3"
+serde = { version = "1.0.116", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //! ```
 
 extern crate fid;
+extern crate serde;
 
 mod louds;
 pub mod trie;

--- a/src/louds.rs
+++ b/src/louds.rs
@@ -1,5 +1,7 @@
 use fid::{BitVector, FID};
+use serde::{Serialize, Deserialize};
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct Louds(BitVector);
 
 impl Louds {


### PR DESCRIPTION
There are a handful of traits that `fid::BitVector` implements that could be automatically derived for `Louds`, so this PR adds those.